### PR TITLE
Javatime via threetenbp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,6 @@ cache:
     - $HOME/.sbt
     - $HOME/.ivy2
 
-before_install:
-  - npm install source-map-support
-  - phantomjs --version
-  - npm install phantomjs-prebuilt
-  - export PATH=$PWD/node_modules/phantomjs-prebuilt/lib/phantom/bin:$PATH
-  - phantomjs --version
-
 script:
   - sbt ++$TRAVIS_SCALA_VERSION clean coverage cron4sJVM/test
 

--- a/core/shared/src/main/scala/cron4s/japi/threetenbp.scala
+++ b/core/shared/src/main/scala/cron4s/japi/threetenbp.scala
@@ -12,7 +12,7 @@ import org.threeten.bp.temporal.{ChronoField, Temporal, TemporalField}
   */
 object threetenbp {
 
-  implicit def javaTimeAdapter[DT <: Temporal]: DateTimeAdapter[DT] = new DateTimeAdapter[DT] {
+  implicit def jsr310Adapter[DT <: Temporal]: DateTimeAdapter[DT] = new DateTimeAdapter[DT] {
 
     private[this] def mapField(field: CronField): TemporalField = field match {
       case Minute     => ChronoField.MINUTE_OF_HOUR

--- a/core/shared/src/main/scala/cron4s/japi/threetenbp.scala
+++ b/core/shared/src/main/scala/cron4s/japi/threetenbp.scala
@@ -1,0 +1,46 @@
+package cron4s.japi
+
+import cron4s.CronField
+import cron4s.CronField._
+import cron4s.expr.{CronExpr, Expr}
+import cron4s.ext.{DateTimeAdapter, ExtendedCronExpr, ExtendedExpr}
+
+import org.threeten.bp.temporal.{ChronoField, Temporal, TemporalField}
+
+/**
+  * Created by alonsodomin on 11/08/2016.
+  */
+object threetenbp {
+
+  implicit def javaTimeAdapter[DT <: Temporal]: DateTimeAdapter[DT] = new DateTimeAdapter[DT] {
+
+    private[this] def mapField(field: CronField): TemporalField = field match {
+      case Minute     => ChronoField.MINUTE_OF_HOUR
+      case Hour       => ChronoField.HOUR_OF_DAY
+      case DayOfMonth => ChronoField.DAY_OF_MONTH
+      case Month      => ChronoField.MONTH_OF_YEAR
+      case DayOfWeek  => ChronoField.DAY_OF_WEEK
+    }
+
+    override def get[F <: CronField](dateTime: DT, field: F): Option[Int] = {
+      val temporalField = mapField(field)
+
+      val offset = if (field == DayOfWeek) -1 else 0
+      if (!dateTime.isSupported(temporalField)) None
+      else Some(dateTime.get(temporalField) + offset)
+    }
+
+    override def set[F <: CronField](dateTime: DT, field: F, value: Int): Option[DT] = {
+      val temporalField = mapField(field)
+
+      val offset = if (field == DayOfWeek) 1 else 0
+      if (!dateTime.isSupported(temporalField)) None
+      else Some(dateTime.`with`(temporalField, value.toLong + offset).asInstanceOf[DT])
+    }
+
+  }
+
+  implicit class Java8Expr[F <: CronField, DT <: Temporal](expr: Expr[F]) extends ExtendedExpr[F, DT](expr)
+  implicit class Java8CronExpr[DT <: Temporal](expr: CronExpr) extends ExtendedCronExpr[DT](expr)
+
+}

--- a/core/shared/src/main/scala/cron4s/japi/threetenbp.scala
+++ b/core/shared/src/main/scala/cron4s/japi/threetenbp.scala
@@ -40,7 +40,7 @@ object threetenbp {
 
   }
 
-  implicit class Java8Expr[F <: CronField, DT <: Temporal](expr: Expr[F]) extends ExtendedExpr[F, DT](expr)
-  implicit class Java8CronExpr[DT <: Temporal](expr: CronExpr) extends ExtendedCronExpr[DT](expr)
+  implicit class JSR3108Expr[F <: CronField, DT <: Temporal](expr: Expr[F]) extends ExtendedExpr[F, DT](expr)
+  implicit class JSR310CronExpr[DT <: Temporal](expr: CronExpr) extends ExtendedCronExpr[DT](expr)
 
 }

--- a/core/shared/src/test/scala/cron4s/japi/ThreeTenBPSpec.scala
+++ b/core/shared/src/test/scala/cron4s/japi/ThreeTenBPSpec.scala
@@ -1,0 +1,37 @@
+package cron4s.japi
+
+import cron4s.CronField._
+import cron4s.expr.{AnyExpr, ConstExpr, CronExpr}
+
+import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+import shapeless._
+
+import org.threeten.bp.LocalDateTime
+import org.threeten.bp.temporal.Temporal
+
+/**
+  * Created by alonsodomin on 11/08/2016.
+  */
+class ThreeTenBPSpec extends PropSpec with TableDrivenPropertyChecks with Matchers {
+  import threetenbp._
+
+  val onlyTuesdaysAt12 = CronExpr(ConstExpr(Minute, 0) :: ConstExpr(Hour, 12) ::
+    AnyExpr[DayOfMonth.type] :: AnyExpr[Month.type] :: ConstExpr(DayOfWeek, 1) :: HNil)
+  val onlySundays = CronExpr(AnyExpr[Minute.type] :: AnyExpr[Hour.type] ::
+    AnyExpr[DayOfMonth.type] :: AnyExpr[Month.type] :: ConstExpr(DayOfWeek, 6) :: HNil)
+
+  val samples = Table(
+    ("expr", "from", "stepSize", "expected"),
+    (onlyTuesdaysAt12, LocalDateTime.of(2016, 8, 1, 0, 0), 1, LocalDateTime.of(2016, 8, 2, 12, 0)),
+    (onlySundays, LocalDateTime.of(2016, 8, 1, 0, 0), 1, LocalDateTime.of(2016, 8, 7, 0, 1))
+  )
+
+  property("step") {
+    forAll(samples) { (expr: CronExpr, initial: Temporal, stepSize: Int, expected: Temporal) =>
+      expr.step(initial, stepSize) shouldBe Some(expected)
+    }
+  }
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,6 +17,8 @@ object Dependencies {
 
     val scalacheck  = "1.12.5"
     val scalatest   = "3.0.0"
+
+    val scalaJavaTime = "2.0.0-M3"
   }
 
   lazy val core = Def.settings {
@@ -25,10 +27,11 @@ object Dependencies {
       compilerPlugin("org.spire-math"  % "kind-projector" % "0.8.0" cross CrossVersion.binary),
 
       "com.chuusai"    %%% "shapeless"                 % version.shapeless,
+      "io.github.soc"  %%% "scala-java-time"           % version.scalaJavaTime,
       "org.scalaz"     %%% "scalaz-core"               % version.scalaz,
-      "org.scalaz"     %%% "scalaz-scalacheck-binding" % version.scalaz     % Test,
-      "org.scalacheck" %%% "scalacheck"                % version.scalacheck % Test,
-      "org.scalatest"  %%% "scalatest"                 % version.scalatest  % Test
+      "org.scalaz"     %%% "scalaz-scalacheck-binding" % version.scalaz         % Test,
+      "org.scalacheck" %%% "scalacheck"                % version.scalacheck     % Test,
+      "org.scalatest"  %%% "scalatest"                 % version.scalatest      % Test
     )
   }
 


### PR DESCRIPTION
We can compile and do all the required operations in time objects in the threeten backport of the JSR310 that has been translated to Scala.

The idea is to drop the original support for JavaTime once the JSR310 port moves to use the the `java.time` package as this will give exactly the same functionality in Scala & ScalaJS.