### PR TITLE
Preserve "step intertia" when calculating a next or previous date

### DIFF
--- a/core/shared/src/main/scala/cron4s/base/Enumerated.scala
+++ b/core/shared/src/main/scala/cron4s/base/Enumerated.scala
@@ -34,7 +34,9 @@ trait Enumerated[A] {
   def min(a: A): Int = range(a).min
   def max(a: A): Int = range(a).max
 
-  private[cron4s] def stepInDirection(a: A, from: Int, stepSize: Int, direction: Direction): Option[(Int, Int, Direction)] = {
+  private[cron4s] def stepInDirection(
+      a: A, from: Int, stepSize: Int, direction: Direction
+  ): Option[(Int, Int, Direction)] = {
     if (stepSize == Int.MinValue || stepSize == Int.MaxValue) {
       None
     } else {
@@ -42,36 +44,27 @@ trait Enumerated[A] {
 
       val nearestNeighbourIndex = direction match {
         case Direction.Forward =>
-          aRange.lastIndexWhere(from >= _)
-
-        case Direction.Backwards =>
           val idx = aRange.indexWhere(from <= _)
           if (idx == -1) aRange.size
           else idx
+
+        case Direction.Backwards =>
+          aRange.lastIndexWhere(from >= _)
       }
 
-      if (stepSize != 0) {
-        val pointer = nearestNeighbourIndex + stepSize
-        val index = {
-          val mod = pointer % aRange.size
-          if (mod < 0) aRange.size + mod
-          else mod
-        }
-        val offsetPointer = if (pointer < 0) {
-          pointer - (aRange.size - 1)
-        } else {
-          pointer
-        }
-
-        (aRange(index), offsetPointer / aRange.size, direction).some
+      val pointer = nearestNeighbourIndex + stepSize
+      val index = {
+        val mod = pointer % aRange.size
+        if (mod < 0) aRange.size + mod
+        else mod
+      }
+      val offsetPointer = if (pointer < 0) {
+        pointer - (aRange.size - 1)
       } else {
-        val result = {
-          if (from <= min(a)) min(a)
-          else if (from >= max(a)) max(a)
-          else from
-        }
-        (result, 0, direction).some
+        pointer
       }
+
+      (aRange(index), offsetPointer / aRange.size, direction).some
     }
   }
 

--- a/core/shared/src/main/scala/cron4s/base/Enumerated.scala
+++ b/core/shared/src/main/scala/cron4s/base/Enumerated.scala
@@ -57,6 +57,13 @@ trait Enumerated[A] {
           aRange.lastIndexWhere(from >= _)
       }
 
+      val currentIndex = if (aRange.contains(a)) {
+        aRange.indexOf(a)
+      } else direction match {
+        case Direction.Forward   => nearestNeighbourIndex - 1
+        case Direction.Backwards => nearestNeighbourIndex + 1
+      }
+
       val pointer = nearestNeighbourIndex + stepSize
       val index = {
         val mod = pointer % aRange.size

--- a/core/shared/src/main/scala/cron4s/base/Enumerated.scala
+++ b/core/shared/src/main/scala/cron4s/base/Enumerated.scala
@@ -25,6 +25,11 @@ import Scalaz._
 
 private[cron4s] sealed trait Direction
 private[cron4s] object Direction {
+  def of(step: Int): Direction = {
+    if (step >= 0) Forward
+    else Backwards
+  }
+
   case object Forward extends Direction
   case object Backwards extends Direction
 }
@@ -34,9 +39,9 @@ trait Enumerated[A] {
   def min(a: A): Int = range(a).min
   def max(a: A): Int = range(a).max
 
-  private[cron4s] def stepInDirection(
+  private[cron4s] def step0(
       a: A, from: Int, stepSize: Int, direction: Direction
-  ): Option[(Int, Int, Direction)] = {
+  ): Option[(Int, Int)] = {
     if (stepSize == Int.MinValue || stepSize == Int.MaxValue) {
       None
     } else {
@@ -64,20 +69,12 @@ trait Enumerated[A] {
         pointer
       }
 
-      (aRange(index), offsetPointer / aRange.size, direction).some
+      (aRange(index), offsetPointer / aRange.size).some
     }
   }
 
-  def step(a: A)(from: Int, stepSize: Int): Option[(Int, Int)] = {
-    val direction = {
-      if (stepSize >= 0) Direction.Forward
-      else Direction.Backwards
-    }
-
-    stepInDirection(a, from, stepSize, direction).map { case (res, co, _) =>
-      res -> co
-    }
-  }
+  def step(a: A)(from: Int, stepSize: Int): Option[(Int, Int)] =
+    step0(a, from, stepSize, Direction.of(stepSize))
 
   def next(a: A)(from: Int): Option[Int] = step(a)(from, 1).map(_._1)
   def prev(a: A)(from: Int): Option[Int] = step(a)(from, -1).map(_._1)

--- a/core/shared/src/main/scala/cron4s/datetime/Stepper.scala
+++ b/core/shared/src/main/scala/cron4s/datetime/Stepper.scala
@@ -84,7 +84,8 @@ private[datetime] final class Stepper[DateTime](DT: IsDateTime[DateTime]) {
       }
     }
 
-    dateStepLoop(Some(from -> step): Step)
+    //dateStepLoop(Some(from -> step): Step)
+    doStep(Some(from -> step): Step)
   }
 
   def stepOverTime(rawExpr: RawTimeCronExpr, from: DateTime, initial: Int): Step =

--- a/core/shared/src/main/scala/cron4s/syntax/enumerated.scala
+++ b/core/shared/src/main/scala/cron4s/syntax/enumerated.scala
@@ -27,8 +27,8 @@ private[syntax] class EnumeratedOps[A](self: A, tc: Enumerated[A]) {
   def max: Int = tc.max(self)
   def min: Int = tc.min(self)
   def step(from: Int, stepSize: Int): Option[(Int, Int)] = tc.step(self)(from, stepSize)
-  private[cron4s] def stepInDirection(from: Int, stepSize: Int, direction: Direction): Option[(Int, Int, Direction)] =
-    tc.stepInDirection(self, from, stepSize, direction)
+  private[cron4s] def step0(from: Int, stepSize: Int, direction: Direction): Option[(Int, Int)] =
+    tc.step0(self, from, stepSize, direction)
   def next(from: Int): Option[Int] = tc.next(self)(from)
   def prev(from: Int): Option[Int] = tc.prev(self)(from)
   def range: IndexedSeq[Int] = tc.range(self)

--- a/core/shared/src/main/scala/cron4s/syntax/enumerated.scala
+++ b/core/shared/src/main/scala/cron4s/syntax/enumerated.scala
@@ -16,7 +16,7 @@
 
 package cron4s.syntax
 
-import cron4s.base.Enumerated
+import cron4s.base.{Direction, Enumerated}
 
 import scala.language.higherKinds
 
@@ -27,6 +27,8 @@ private[syntax] class EnumeratedOps[A](self: A, tc: Enumerated[A]) {
   def max: Int = tc.max(self)
   def min: Int = tc.min(self)
   def step(from: Int, stepSize: Int): Option[(Int, Int)] = tc.step(self)(from, stepSize)
+  private[cron4s] def stepInDirection(from: Int, stepSize: Int, direction: Direction): Option[(Int, Int, Direction)] =
+    tc.stepInDirection(self, from, stepSize, direction)
   def next(from: Int): Option[Int] = tc.next(self)(from)
   def prev(from: Int): Option[Int] = tc.prev(self)(from)
   def range: IndexedSeq[Int] = tc.range(self)

--- a/testkit/src/main/scala/cron4s/testkit/discipline/EnumeratedTests.scala
+++ b/testkit/src/main/scala/cron4s/testkit/discipline/EnumeratedTests.scala
@@ -39,14 +39,14 @@ trait EnumeratedTests[A] extends Laws {
     "max" -> forAll(laws.max _),
     "forward" -> forAll(laws.forward _),
     "backwards" -> forAll(laws.backwards _),
-    "zeroStepSize" -> forAll(laws.zeroStepSize _),
+    "zeroStepSize" -> forAll(laws.zeroStepSize2 _),
     "fromMinToMinForwards" -> forAll(laws.fromMinToMinForwards _),
     "fromMaxToMaxForwards" -> forAll(laws.fromMaxToMaxForwards _),
     "fromMinToMaxForwards" -> forAll(laws.fromMinToMaxForwards _),
     "fromMinToMaxBackwards" -> forAll(laws.fromMinToMaxBackwards _),
     "fromMaxToMinForwards" -> forAll(laws.fromMaxToMinForwards _),
-    "fromMaxToMinBackwards" -> forAll(laws.fromMaxToMinBackwards _),
-    "backAndForth" -> forAll(laws.backAndForth _)
+    "fromMaxToMinBackwards" -> forAll(laws.fromMaxToMinBackwards _)
+    //"backAndForth" -> forAll(laws.backAndForth _)
   )
 
 }

--- a/testkit/src/main/scala/cron4s/testkit/discipline/EnumeratedTests.scala
+++ b/testkit/src/main/scala/cron4s/testkit/discipline/EnumeratedTests.scala
@@ -39,14 +39,14 @@ trait EnumeratedTests[A] extends Laws {
     "max" -> forAll(laws.max _),
     "forward" -> forAll(laws.forward _),
     "backwards" -> forAll(laws.backwards _),
-    "zeroStepSize" -> forAll(laws.zeroStepSize2 _),
+    "zeroStepSize" -> forAll(laws.zeroStepSize _),
     "fromMinToMinForwards" -> forAll(laws.fromMinToMinForwards _),
     "fromMaxToMaxForwards" -> forAll(laws.fromMaxToMaxForwards _),
     "fromMinToMaxForwards" -> forAll(laws.fromMinToMaxForwards _),
     "fromMinToMaxBackwards" -> forAll(laws.fromMinToMaxBackwards _),
     "fromMaxToMinForwards" -> forAll(laws.fromMaxToMinForwards _),
-    "fromMaxToMinBackwards" -> forAll(laws.fromMaxToMinBackwards _)
-    //"backAndForth" -> forAll(laws.backAndForth _)
+    "fromMaxToMinBackwards" -> forAll(laws.fromMaxToMinBackwards _),
+    "backAndForth" -> forAll(laws.backAndForth _)
   )
 
 }

--- a/testkit/src/main/scala/cron4s/testkit/laws/EnumeratedLaws.scala
+++ b/testkit/src/main/scala/cron4s/testkit/laws/EnumeratedLaws.scala
@@ -16,9 +16,14 @@
 
 package cron4s.testkit.laws
 
-import cron4s.testkit._
-import cron4s.base.Enumerated
+import cron4s.base.{Direction, Enumerated}
 import cron4s.syntax.enumerated._
+import cron4s.testkit._
+
+import org.scalacheck.Prop
+
+import scalaz._
+import Scalaz._
 
 /**
   * Created by alonsodomin on 27/08/2016.
@@ -52,6 +57,12 @@ trait EnumeratedLaws[A] {
 
   def zeroStepSize(a: A, from: Int): IsEqual[Option[(Int, Int)]] = {
     a.step(from, 0) <-> zeroStepExpected(a, from)
+  }
+
+  private[cron4s] def zeroStepSize2(a: A, from: Int, direction: Direction): Prop = {
+    val stepped = TC.stepInDirection(a, from, 0, direction).map(_._1)
+
+    stepped.map(a.range.contains).map(_ ?== true).getOrElse(proved)
   }
 
   def fromMinToMinForwards(a: A): IsEqual[Option[(Int, Int)]] =

--- a/testkit/src/main/scala/cron4s/testkit/laws/EnumeratedLaws.scala
+++ b/testkit/src/main/scala/cron4s/testkit/laws/EnumeratedLaws.scala
@@ -60,7 +60,7 @@ trait EnumeratedLaws[A] {
   }
 
   private[cron4s] def zeroStepSize2(a: A, from: Int, direction: Direction): Boolean = {
-    val stepped = TC.stepInDirection(a, from, 0, direction)
+    val stepped = TC.step0(a, from, 0, direction)
 
     stepped.forall { case (result, carryOver, _) => a.range.contains(result) && carryOver == 0 }
   }

--- a/testkit/src/main/scala/cron4s/testkit/laws/EnumeratedLaws.scala
+++ b/testkit/src/main/scala/cron4s/testkit/laws/EnumeratedLaws.scala
@@ -59,10 +59,10 @@ trait EnumeratedLaws[A] {
     a.step(from, 0) <-> zeroStepExpected(a, from)
   }
 
-  private[cron4s] def zeroStepSize2(a: A, from: Int, direction: Direction): Prop = {
-    val stepped = TC.stepInDirection(a, from, 0, direction).map(_._1)
+  private[cron4s] def zeroStepSize2(a: A, from: Int, direction: Direction): Boolean = {
+    val stepped = TC.stepInDirection(a, from, 0, direction)
 
-    stepped.map(a.range.contains).map(_ ?== true).getOrElse(proved)
+    stepped.forall { case (result, carryOver, _) => a.range.contains(result) && carryOver == 0 }
   }
 
   def fromMinToMinForwards(a: A): IsEqual[Option[(Int, Int)]] =

--- a/tests/shared/src/test/scala/cron4s/expr/BetweenNodeSpec.scala
+++ b/tests/shared/src/test/scala/cron4s/expr/BetweenNodeSpec.scala
@@ -24,7 +24,7 @@ import cron4s.testkit.gen.ArbitraryBetweenNode
 /**
   * Created by alonsodomin on 31/07/2016.
   */
-class BetweenSpec extends Cron4sLawSuite with ArbitraryBetweenNode {
+class BetweenNodeSpec extends Cron4sLawSuite with ArbitraryBetweenNode {
 
   checkAll("Between[Second]", FieldExprTests[BetweenNode, Second].expr)
   checkAll("Between[Minute]", FieldExprTests[BetweenNode, Minute].expr)

--- a/tests/shared/src/test/scala/cron4s/lib/threetenbp/CronDateTimeRegressionSpec.scala
+++ b/tests/shared/src/test/scala/cron4s/lib/threetenbp/CronDateTimeRegressionSpec.scala
@@ -16,13 +16,25 @@
 
 package cron4s.lib.threetenbp
 
+import cron4s._
+
 import org.scalatest.{FlatSpec, Matchers}
+
+import org.threeten.bp.LocalDateTime
+import org.threeten.bp.temporal.ChronoUnit
 
 /**
   * Created by domingueza on 20/02/2017.
   */
-class RegressionSpec extends FlatSpec with Matchers {
+class CronDateTimeRegressionSpec extends FlatSpec with Matchers {
 
+  "Cron" should "not advance to the next day" in {
+    val from = LocalDateTime.parse("2017-02-18T16:39:42.541")
 
+    val Right(cron) = Cron("* */10 * * * *")
+    val Some(next) = cron.next(from)
+
+    from.until(next, ChronoUnit.SECONDS) <= 600 shouldBe true
+  }
 
 }

--- a/tests/shared/src/test/scala/cron4s/lib/threetenbp/RegressionSpec.scala
+++ b/tests/shared/src/test/scala/cron4s/lib/threetenbp/RegressionSpec.scala
@@ -14,23 +14,15 @@
  * limitations under the License.
  */
 
-package cron4s.testkit
+package cron4s.lib.threetenbp
 
-import cron4s.base.Direction
-import org.scalacheck.{Arbitrary, Gen, Prop}
-
-import scala.language.implicitConversions
-import scalaz.Equal
+import org.scalatest.{FlatSpec, Matchers}
 
 /**
-  * Created by alonsodomin on 03/01/2017.
+  * Created by domingueza on 20/02/2017.
   */
-package object discipline {
+class RegressionSpec extends FlatSpec with Matchers {
 
-  implicit def isEqualToProp[A: Equal](isEqual: IsEqual[A]): Prop =
-    isEqual.lhs ?== isEqual.rhs
 
-  private[cron4s] val directionGen: Gen[Direction] = Gen.oneOf(Direction.Forward, Direction.Backwards)
-  private[cron4s] implicit lazy val arbitraryDirection: Arbitrary[Direction] = Arbitrary(directionGen)
 
 }


### PR DESCRIPTION
Fixes #50

_Step intertia_ refers to carrying over the direction of the step operation across the different fields in the Cron expression even when the carry over value from the previous field is equal to 0. Ignoring this inertia results in invalid result values for those fields constrained by non-continuous sub-expressions and other potential side effects.

This PR fixes this problem and adds a regression test to prevent future ocurrences.