### PR TITLE
Export Cron entrypoint as module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,7 @@ lazy val coverageSettings = Seq(
 )
 
 def mimaSettings(module: String): Seq[Setting[_]] = mimaDefaultSettings ++ Seq(
-  mimaPreviousArtifacts := Set("com.github.alonsodomin.cron4s" %% s"cron4s-${module}" % "0.3.0")
+  mimaPreviousArtifacts := Set("com.github.alonsodomin.cron4s" %% s"cron4s-${module}" % "0.3.2")
 )
 
 lazy val docsMappingsAPIDir = settingKey[String]("Name of subdirectory in site target directory for api docs")
@@ -182,7 +182,7 @@ lazy val cron4sJS = (project in file(".js")).
   settings(publishSettings).
   enablePlugins(ScalaJSPlugin).
   aggregate(coreJS, testkitJS, testsJS).
-  dependsOn(coreJS, testkitJS, testsJS  % "test")
+  dependsOn(coreJS, testkitJS % "test", testsJS  % "test")
 
 lazy val cron4sJVM = (project in file(".jvm")).
   settings(
@@ -193,7 +193,7 @@ lazy val cron4sJVM = (project in file(".jvm")).
   settings(commonJvmSettings: _*).
   settings(publishSettings).
   aggregate(coreJVM, testkitJVM, testsJVM).
-  dependsOn(coreJVM, testkitJVM, testsJVM % "test")
+  dependsOn(coreJVM, testkitJVM % "test", testsJVM % "test")
 
 lazy val docs = project.
   enablePlugins(MicrositesPlugin).

--- a/build.sbt
+++ b/build.sbt
@@ -182,7 +182,7 @@ lazy val cron4sJS = (project in file(".js")).
   settings(publishSettings).
   enablePlugins(ScalaJSPlugin).
   aggregate(coreJS, testkitJS, testsJS).
-  dependsOn(coreJS, testkitJS % "test", testsJS  % "test")
+  dependsOn(coreJS, testkitJS, testsJS  % "test")
 
 lazy val cron4sJVM = (project in file(".jvm")).
   settings(
@@ -193,7 +193,7 @@ lazy val cron4sJVM = (project in file(".jvm")).
   settings(commonJvmSettings: _*).
   settings(publishSettings).
   aggregate(coreJVM, testkitJVM, testsJVM).
-  dependsOn(coreJVM, testkitJVM % "test", testsJVM % "test")
+  dependsOn(coreJVM, testkitJVM, testsJVM % "test")
 
 lazy val docs = project.
   enablePlugins(MicrositesPlugin).

--- a/core/js/src/main/scala/cron4s/Cron.scala
+++ b/core/js/src/main/scala/cron4s/Cron.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Antonio Alonso Dominguez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cron4s
+
+import scala.scalajs.js.annotation.JSExportTopLevel
+
+/**
+  * Created by domingueza on 10/04/2017.
+  */
+@JSExportTopLevel("cron4s.Cron")
+object Cron extends CronImpl

--- a/core/jvm/src/main/scala/cron4s/Cron.scala
+++ b/core/jvm/src/main/scala/cron4s/Cron.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 Antonio Alonso Dominguez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cron4s
+
+/**
+  * Created by domingueza on 10/04/2017.
+  */
+object Cron extends CronImpl

--- a/core/shared/src/main/scala/cron4s/CronImpl.scala
+++ b/core/shared/src/main/scala/cron4s/CronImpl.scala
@@ -21,11 +21,9 @@ import cron4s.expr._
 import fastparse.all._
 
 /**
-  * Entry point for the CRON parsing operation
-  *
-  * @author Antonio Alonso Dominguez
+  * Created by domingueza on 10/04/2017.
   */
-object Cron {
+private[cron4s] trait CronImpl {
 
   def apply(e: String): Either[InvalidCron, CronExpr] =
     parse(e).right.flatMap(validation.validateCron)

--- a/core/shared/src/main/scala/cron4s/CronImpl.scala
+++ b/core/shared/src/main/scala/cron4s/CronImpl.scala
@@ -25,8 +25,11 @@ import fastparse.all._
   */
 private[cron4s] trait CronImpl {
 
-  def apply(e: String): Either[InvalidCron, CronExpr] =
-    parse(e).right.flatMap(validation.validateCron)
+  def apply(e: String): Either[InvalidCron, CronExpr] = {
+    // Needed for Scala 2.11
+    import cats.syntax.either._
+    parse(e).flatMap(validation.validateCron)
+  }
 
   private[this] def parse(e: String): Either[ParseFailed, CronExpr] = {
     parser.cron.parse(e) match {


### PR DESCRIPTION
This PR exports the singleton object `Cron` used as an entry point to the parser as a CommonJS module in JavaScript land.

The ScalaJS + Webpack integration is not ready yet for proper show-time to deal with exporting and packaging individual libraries so it was post-poned.

Fixes #65.