### PR TITLE
Fix month rolling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,8 +36,7 @@ val commonSettings = Def.settings(
     "-language:postfixOps",
     "-language:implicitConversions",
     "-language:higherKinds",
-    "-language:existentials",
-    "-Ywarn-unused-import"
+    "-language:existentials"
   ),
   botBuild := scala.sys.env.get("TRAVIS").isDefined,
   parallelExecution in Test := false,

--- a/core/js/src/main/scala/cron4s/lib/js/JsDateInstance.scala
+++ b/core/js/src/main/scala/cron4s/lib/js/JsDateInstance.scala
@@ -17,7 +17,7 @@
 package cron4s.lib.js
 
 import cron4s.CronField
-import cron4s.datetime.{DateTimeUnit, IsDateTime}
+import cron4s.datetime.{DateTimeError, DateTimeUnit, IsDateTime}
 
 import scala.scalajs.js.Date
 
@@ -76,14 +76,14 @@ private[js] final class JsDateInstance extends IsDateTime[Date] {
 
   override def set[F <: CronField](dateTime: Date,
                                    field: F,
-                                   value: Int): Option[Date] = {
+                                   value: Int): Either[DateTimeError, Date] = {
     def setter(setter: Date => Unit): Date = {
       val newDateTime = new Date(dateTime.getTime())
       setter(newDateTime)
       newDateTime
     }
 
-    Some(field match {
+    Right(field match {
       case Second     => setter(_.setUTCSeconds(value, 0))
       case Minute     => setter(_.setUTCMinutes(value))
       case Hour       => setter(_.setUTCHours(value))

--- a/core/js/src/main/scala/cron4s/lib/js/JsDateInstance.scala
+++ b/core/js/src/main/scala/cron4s/lib/js/JsDateInstance.scala
@@ -17,7 +17,12 @@
 package cron4s.lib.js
 
 import cron4s.CronField
-import cron4s.datetime.{DateTimeError, DateTimeUnit, IsDateTime}
+import cron4s.datetime.{
+  DateTimeError,
+  DateTimeUnit,
+  InvalidFieldValue,
+  IsDateTime
+}
 
 import scala.scalajs.js.Date
 
@@ -83,7 +88,7 @@ private[js] final class JsDateInstance extends IsDateTime[Date] {
       newDateTime
     }
 
-    Right(field match {
+    def assignFieldValue: Date = field match {
       case Second     => setter(_.setUTCSeconds(value, 0))
       case Minute     => setter(_.setUTCMinutes(value))
       case Hour       => setter(_.setUTCHours(value))
@@ -93,7 +98,14 @@ private[js] final class JsDateInstance extends IsDateTime[Date] {
         val dayToSet = (value % DaysInWeek) + 1
         val offset = dayToSet - dateTime.getUTCDay()
         setter(d => d.setUTCDate(d.getUTCDate() + offset))
-    })
+    }
+
+    def assignmentSucceeded(date: Date) =
+      get[F](date, field).contains(value)
+
+    val modifiedDate = assignFieldValue
+    if (assignmentSucceeded(modifiedDate)) Right(modifiedDate)
+    else Left(InvalidFieldValue(field, value))
   }
 
 }

--- a/core/shared/src/main/scala/cron4s/datetime/DateTimeNode.scala
+++ b/core/shared/src/main/scala/cron4s/datetime/DateTimeNode.scala
@@ -66,6 +66,7 @@ trait DateTimeNode[E[_ <: CronField], F <: CronField] {
     * @return a date-time that is an amount of given steps from the given one
     */
   def stepIn[DateTime](expr: E[F], DT: IsDateTime[DateTime])(dateTime: DateTime, step: Int): Option[DateTime] = {
+    import cats.syntax.either._
     for {
       current  <- DT.get(dateTime, expr.unit.field)
       newValue <- expr.step(current, step).map(_._1)

--- a/core/shared/src/main/scala/cron4s/datetime/DateTimeNode.scala
+++ b/core/shared/src/main/scala/cron4s/datetime/DateTimeNode.scala
@@ -69,7 +69,7 @@ trait DateTimeNode[E[_ <: CronField], F <: CronField] {
     for {
       current  <- DT.get(dateTime, expr.unit.field)
       newValue <- expr.step(current, step).map(_._1)
-      adjusted <- DT.set(dateTime, expr.unit.field, newValue)
+      adjusted <- DT.set(dateTime, expr.unit.field, newValue).toOption
     } yield adjusted
   }
 

--- a/core/shared/src/main/scala/cron4s/datetime/IsDateTime.scala
+++ b/core/shared/src/main/scala/cron4s/datetime/IsDateTime.scala
@@ -54,7 +54,7 @@ trait IsDateTime[DateTime] {
     * @tparam F the CronField type
     * @return a new date-time with the given field set to the new value
     */
-  def set[F <: CronField](dateTime: DateTime, field: F, value: Int): Option[DateTime]
+  def set[F <: CronField](dateTime: DateTime, field: F, value: Int): Either[DateTimeError, DateTime]
 
 }
 

--- a/core/shared/src/main/scala/cron4s/datetime/Stepper.scala
+++ b/core/shared/src/main/scala/cron4s/datetime/Stepper.scala
@@ -40,7 +40,7 @@ private[datetime] final class Stepper[DateTime](DT: IsDateTime[DateTime]) {
       DT.set(dt, node.unit.field, newValue)
         .map(_ -> carryOver)
         .recover {
-          case InvalidFieldValue(field, value) =>
+          case InvalidFieldValue(_, _) =>
             val newCarryOver = step.direction match {
               case Direction.Forward   => Math.max(carryOver, step.direction.sign)
               case Direction.Backwards => Math.min(carryOver, step.direction.sign)

--- a/core/shared/src/main/scala/cron4s/datetime/Stepper.scala
+++ b/core/shared/src/main/scala/cron4s/datetime/Stepper.scala
@@ -16,6 +16,8 @@
 
 package cron4s.datetime
 
+import cats.syntax.either._
+
 import cron4s._
 import cron4s.base.{Direction, Step}
 import cron4s.expr._
@@ -32,28 +34,41 @@ private[datetime] final class Stepper[DateTime](DT: IsDateTime[DateTime]) {
   private val identityReset: ResetPrevFn = Some(_)
 
   private[this] def stepNode[N[_ <: CronField], F <: CronField]
-      (stepState: StepST, node: N[F])(implicit expr: FieldExpr[N, F]): StepST =
+      (stepState: StepST, node: N[F])(implicit expr: FieldExpr[N, F]): StepST = {
+    def attemptSet(dt: DateTime, step: Step, newValue: Int, carryOver: Int): Option[(DateTime, Int)] = {
+      DT.set(dt, node.unit.field, newValue)
+        .map(_ -> carryOver)
+        .recover {
+          case InvalidFieldValue(_, _) => dt -> (step.direction match {
+            case Direction.Forward   => Math.max(carryOver, step.direction.sign)
+            case Direction.Backwards => Math.min(carryOver, step.direction.sign)
+          })
+        }
+        .toOption
+    }
+
     stepState.flatMap { case (resetPrevious, from, step) =>
       def resetThis: DateTime => Option[DateTime] = {
         val resetValue = step.direction match {
-          case Direction.Forward   => node.min
+          case Direction.Forward => node.min
           case Direction.Backwards => node.max
         }
 
-        resetPrevious.andThen(_.flatMap(DT.set(_, node.unit.field, resetValue)))
+        resetPrevious.andThen(_.flatMap(DT.set(_, node.unit.field, resetValue).toOption))
       }
 
       DT.get(from, node.unit.field).flatMap { currentValue =>
         node.step(currentValue, step) match {
           case Some((newValue, carryOver)) =>
             resetPrevious(from)
-              .flatMap(DT.set(_, node.unit.field, newValue))
-              .map((resetThis, _, step.copy(amount = Math.abs(carryOver))))
+              .flatMap(attemptSet(_, step, newValue, carryOver))
+              .map { case (dt, co) => (resetThis, dt, step.copy(amount = Math.abs(co))) }
 
           case None =>
             Some((resetThis, from, step.copy(amount = 0)))
         }
       }
+    }
   }
 
   private[this] def stepOverMonth(prev: StepST, expr: MonthsNode): StepST = for {

--- a/core/shared/src/main/scala/cron4s/datetime/errors.scala
+++ b/core/shared/src/main/scala/cron4s/datetime/errors.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Antonio Alonso Dominguez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cron4s.datetime
 
 import cron4s.CronField

--- a/core/shared/src/main/scala/cron4s/datetime/errors.scala
+++ b/core/shared/src/main/scala/cron4s/datetime/errors.scala
@@ -1,0 +1,7 @@
+package cron4s.datetime
+
+import cron4s.CronField
+
+sealed trait DateTimeError
+final case class UnsupportedField(field: CronField) extends DateTimeError
+final case class InvalidFieldValue(field: CronField, value: Int) extends DateTimeError

--- a/docs/src/main/tut/docs/custom_datetime.md
+++ b/docs/src/main/tut/docs/custom_datetime.md
@@ -30,7 +30,7 @@ Now that we have a way of representing time, we need to provide an instance for 
 
 ```tut:silent
 import cron4s._
-import cron4s.datetime.{DateTimeUnit, IsDateTime}
+import cron4s.datetime._
 
 implicit object MyDateInstance extends IsDateTime[MyTime] {
 
@@ -46,11 +46,11 @@ implicit object MyDateInstance extends IsDateTime[MyTime] {
     case _                => None
   }
   
-  def set[F <: CronField](myTime: MyTime, field: F, value: Int): Option[MyTime] = field match {
-    case CronField.Second => Some(myTime.copy(seconds = value))
-    case CronField.Minute => Some(myTime.copy(minutes = value))
-    case CronField.Hour   => Some(myTime.copy(hour = value))
-    case _                => None
+  def set[F <: CronField](myTime: MyTime, field: F, value: Int): Either[DateTimeError, MyTime] = field match {
+    case CronField.Second => Right(myTime.copy(seconds = value))
+    case CronField.Minute => Right(myTime.copy(minutes = value))
+    case CronField.Hour   => Right(myTime.copy(hour = value))
+    case _                => Left(UnsupportedField(field))
   }
 
 }

--- a/testkit/src/main/scala/cron4s/testkit/CronDateTimeTestKit.scala
+++ b/testkit/src/main/scala/cron4s/testkit/CronDateTimeTestKit.scala
@@ -60,7 +60,7 @@ abstract class CronDateTimeTestKit[DateTime: IsDateTime: Eq: Show]
     (BetweenMonth,         createDateTime(0, 1, 1, 4, 11, 2016),         1, createDateTime(0, 0, 0, 1, 4, 2017)),
     (Every10Minutes,       createDateTime(42, 39, 16, 18, 2, 2017),      1, createDateTime(0, 40, 16, 18, 2, 2017)),
     (Every31DayOfMonth,    createDateTime(0, 0, 0, 4, 9, 2016),          1, createDateTime(1, 1, 1, 31, 10, 2016)),
-    (AnyDayOfMonth,        createDateTime(45, 30, 23, 30, 6, 2017),      1, createDateTime(4, 31, 3, 1, 7, 2017))
+    (AnyDayOfMonth,        createDateTime(45, 30, 23, 30, 6, 2017),      1, createDateTime(4, 31, 4, 1, 7, 2017))
   )
 
   "Cron.step" should "match expected result" in {

--- a/testkit/src/main/scala/cron4s/testkit/CronDateTimeTestKit.scala
+++ b/testkit/src/main/scala/cron4s/testkit/CronDateTimeTestKit.scala
@@ -39,6 +39,12 @@ object CronDateTimeTestKit {
   // https://github.com/alonsodomin/cron4s/issues/56
   final val Every10Minutes   = Cron.unsafeParse("* */10 * * * ?")
 
+  // https://github.com/alonsodomin/cron4s/issues/73
+  final val Every31DayOfMonth = Cron.unsafeParse("1 1 1 31 * ?")
+
+  // https://github.com/alonsodomin/cron4s/issues/80
+  final val AnyDayOfMonth     = Cron.unsafeParse("4 31 4 ? * *")
+
 }
 
 abstract class CronDateTimeTestKit[DateTime: IsDateTime: Eq: Show]
@@ -52,7 +58,9 @@ abstract class CronDateTimeTestKit[DateTime: IsDateTime: Eq: Show]
     (BetweenDayOfWeek,     createDateTime(0, 0, 2, 11, 3, 2016),         1, createDateTime(0, 0, 0, 15, 3, 2016)),
     (BetweenDayOfWeek,     createDateTime(0, 0, 2, 7, 3, 2016),         -1, createDateTime(0, 0, 0, 3, 3, 2016)),
     (BetweenMonth,         createDateTime(0, 1, 1, 4, 11, 2016),         1, createDateTime(0, 0, 0, 1, 4, 2017)),
-    (Every10Minutes,       createDateTime(42, 39, 16, 18, 2, 2017),      1, createDateTime(0, 40, 16, 18, 2, 2017))
+    (Every10Minutes,       createDateTime(42, 39, 16, 18, 2, 2017),      1, createDateTime(0, 40, 16, 18, 2, 2017)),
+    (Every31DayOfMonth,    createDateTime(0, 0, 0, 4, 9, 2016),          1, createDateTime(1, 1, 1, 31, 10, 2016)),
+    (AnyDayOfMonth,        createDateTime(45, 30, 23, 30, 6, 2017),      1, createDateTime(4, 31, 3, 1, 7, 2017))
   )
 
   "Cron.step" should "match expected result" in {

--- a/testkit/src/main/scala/cron4s/testkit/laws/IsDateTimeLaws.scala
+++ b/testkit/src/main/scala/cron4s/testkit/laws/IsDateTimeLaws.scala
@@ -39,7 +39,7 @@ trait IsDateTimeLaws[DateTime] {
   def immutability[F <: CronField](dt: DateTime, fieldValue: CronFieldValue[F]): Prop = {
     val check = for {
       current     <- DT.get(dt, fieldValue.field)
-      newDateTime <- DT.set(dt, fieldValue.field, fieldValue.value)
+      newDateTime <- DT.set(dt, fieldValue.field, fieldValue.value).toOption
     } yield {
       if (current == fieldValue.value) newDateTime ?== dt
       else newDateTime ?!= dt
@@ -50,7 +50,7 @@ trait IsDateTimeLaws[DateTime] {
 
   def settable[F <: CronField](dt: DateTime, fieldValue: CronFieldValue[F]): Prop = {
     val check = for {
-      newDateTime <- DT.set(dt, fieldValue.field, fieldValue.value)
+      newDateTime <- DT.set(dt, fieldValue.field, fieldValue.value).toOption
       value       <- DT.get(newDateTime, fieldValue.field)
     } yield value ?== fieldValue.value
 

--- a/time-lib/joda/src/main/scala/cron4s/lib/joda/JodaInstances.scala
+++ b/time-lib/joda/src/main/scala/cron4s/lib/joda/JodaInstances.scala
@@ -16,8 +16,10 @@
 
 package cron4s.lib.joda
 
+import cats.syntax.either._
+
 import cron4s._
-import cron4s.datetime.{IsDateTime, DateTimeUnit}
+import cron4s.datetime._
 
 import org.joda.time._
 import org.joda.time.base.BaseLocal
@@ -69,11 +71,9 @@ private[joda] abstract class JodaInstance[DT] extends IsDateTime[DT] {
     */
   override def set[F <: CronField](dateTime: DT,
                                    field: F,
-                                   value: Int): Option[DT] = {
-    val jodaField = asDateTimeFieldType(field)
+                                   value: Int): Either[DateTimeError, DT] = {
     val offset = if (field == DayOfWeek) 1 else 0
-
-    setField(dateTime, jodaField, value + offset)
+    setField(dateTime, field, value + offset)
   }
 
   protected def asPeriod(amount: Int, unit: DateTimeUnit): ReadablePeriod =
@@ -86,7 +86,7 @@ private[joda] abstract class JodaInstance[DT] extends IsDateTime[DT] {
       case DateTimeUnit.Weeks   => Weeks.weeks(amount)
     }
 
-  private[this] def asDateTimeFieldType[F <: CronField](
+  protected def asDateTimeFieldType[F <: CronField](
       field: F): DateTimeFieldType = field match {
     case Second     => DateTimeFieldType.secondOfMinute()
     case Minute     => DateTimeFieldType.minuteOfHour()
@@ -103,8 +103,8 @@ private[joda] abstract class JodaInstance[DT] extends IsDateTime[DT] {
   protected def getField(dateTime: DT, field: DateTimeFieldType): Option[Int]
 
   protected def setField(dateTime: DT,
-                         field: DateTimeFieldType,
-                         value: Int): Option[DT]
+                         field: CronField,
+                         value: Int): Either[DateTimeError, DT]
 
 }
 
@@ -124,15 +124,21 @@ private[joda] final class JodaDateTimeInstance extends JodaInstance[DateTime] {
     else None
   }
 
-  override protected def setField(dateTime: DateTime,
-                                  field: DateTimeFieldType,
-                                  value: Int): Option[DateTime] = {
-    if (dateTime.isSupported(field)) {
-      val newDate = Try(dateTime.withField(field, value)).toOption
+  override protected def setField(
+      dateTime: DateTime,
+      field: CronField,
+      value: Int): Either[DateTimeError, DateTime] = {
+    val fieldType = asDateTimeFieldType(field)
+
+    if (dateTime.isSupported(fieldType)) {
+      val newDate = Either
+        .catchNonFatal(dateTime.withField(fieldType, value))
+        .leftMap(_ => InvalidFieldValue(field, value))
+
       if (field.equals(DateTimeFieldType.secondOfMinute()))
         newDate.map(_.withMillisOfSecond(0))
       else newDate
-    } else None
+    } else UnsupportedField(field).asLeft
   }
 
 }
@@ -159,15 +165,21 @@ private[joda] final class JodaLocalTimeInstance
                                     period: ReadablePeriod): Option[LocalTime] =
     Some(dateTime.plus(period))
 
-  override protected def setField(dateTime: LocalTime,
-                                  field: DateTimeFieldType,
-                                  value: Int): Option[LocalTime] = {
-    if (dateTime.isSupported(field)) {
-      val newDate = Try(dateTime.withField(field, value)).toOption
+  override protected def setField(
+      dateTime: LocalTime,
+      field: CronField,
+      value: Int): Either[DateTimeError, LocalTime] = {
+    val fieldType = asDateTimeFieldType(field)
+
+    if (dateTime.isSupported(fieldType)) {
+      val newDate = Either
+        .fromTry(Try(dateTime.withField(fieldType, value)))
+        .leftMap(_ => InvalidFieldValue(field, value))
+
       if (field.equals(DateTimeFieldType.secondOfMinute()))
         newDate.map(_.withMillisOfSecond(0))
       else newDate
-    } else None
+    } else UnsupportedField(field).asLeft
   }
 
 }
@@ -179,12 +191,17 @@ private[joda] final class JodaLocalDateInstance
                                     period: ReadablePeriod): Option[LocalDate] =
     Try(dateTime.plus(period)).toOption
 
-  override protected def setField(dateTime: LocalDate,
-                                  field: DateTimeFieldType,
-                                  value: Int): Option[LocalDate] = {
-    if (dateTime.isSupported(field)) {
-      Try(dateTime.withField(field, value)).toOption
-    } else None
+  override protected def setField(
+      dateTime: LocalDate,
+      field: CronField,
+      value: Int): Either[DateTimeError, LocalDate] = {
+    val fieldType = asDateTimeFieldType(field)
+
+    if (dateTime.isSupported(fieldType)) {
+      Either
+        .catchNonFatal(dateTime.withField(fieldType, value))
+        .leftMap(_ => InvalidFieldValue(field, value))
+    } else UnsupportedField(field).asLeft
   }
 
 }
@@ -197,15 +214,21 @@ private[joda] final class JodaLocalDateTimeInstance
       period: ReadablePeriod): Option[LocalDateTime] =
     Try(dateTime.plus(period)).toOption
 
-  override protected def setField(dateTime: LocalDateTime,
-                                  field: DateTimeFieldType,
-                                  value: Int): Option[LocalDateTime] = {
-    if (dateTime.isSupported(field)) {
-      val newDate = Try(dateTime.withField(field, value)).toOption
+  override protected def setField(
+      dateTime: LocalDateTime,
+      field: CronField,
+      value: Int): Either[DateTimeError, LocalDateTime] = {
+    val fieldType = asDateTimeFieldType(field)
+
+    if (dateTime.isSupported(fieldType)) {
+      val newDate = Either
+        .catchNonFatal(dateTime.withField(fieldType, value))
+        .leftMap(_ => InvalidFieldValue(field, value))
+
       if (field.equals(DateTimeFieldType.secondOfMinute()))
         newDate.map(_.withMillisOfSecond(0))
       else newDate
-    } else None
+    } else UnsupportedField(field).asLeft
   }
 
 }

--- a/time-lib/joda/src/main/scala/cron4s/lib/joda/JodaInstances.scala
+++ b/time-lib/joda/src/main/scala/cron4s/lib/joda/JodaInstances.scala
@@ -135,7 +135,7 @@ private[joda] final class JodaDateTimeInstance extends JodaInstance[DateTime] {
         .catchNonFatal(dateTime.withField(fieldType, value))
         .leftMap(_ => InvalidFieldValue(field, value))
 
-      if (field.equals(DateTimeFieldType.secondOfMinute()))
+      if (fieldType.equals(DateTimeFieldType.secondOfMinute()))
         newDate.map(_.withMillisOfSecond(0))
       else newDate
     } else UnsupportedField(field).asLeft
@@ -176,7 +176,7 @@ private[joda] final class JodaLocalTimeInstance
         .fromTry(Try(dateTime.withField(fieldType, value)))
         .leftMap(_ => InvalidFieldValue(field, value))
 
-      if (field.equals(DateTimeFieldType.secondOfMinute()))
+      if (fieldType.equals(DateTimeFieldType.secondOfMinute()))
         newDate.map(_.withMillisOfSecond(0))
       else newDate
     } else UnsupportedField(field).asLeft
@@ -225,7 +225,7 @@ private[joda] final class JodaLocalDateTimeInstance
         .catchNonFatal(dateTime.withField(fieldType, value))
         .leftMap(_ => InvalidFieldValue(field, value))
 
-      if (field.equals(DateTimeFieldType.secondOfMinute()))
+      if (fieldType.equals(DateTimeFieldType.secondOfMinute()))
         newDate.map(_.withMillisOfSecond(0))
       else newDate
     } else UnsupportedField(field).asLeft

--- a/time-lib/momentjs/src/main/scala/cron4s/lib/momentjs/MomentJSInstance.scala
+++ b/time-lib/momentjs/src/main/scala/cron4s/lib/momentjs/MomentJSInstance.scala
@@ -17,7 +17,7 @@
 package cron4s.lib.momentjs
 
 import cron4s.CronField
-import cron4s.datetime.{DateTimeUnit, IsDateTime}
+import cron4s.datetime.{DateTimeError, DateTimeUnit, IsDateTime}
 
 import moment._
 
@@ -86,14 +86,14 @@ private[momentjs] final class MomentJSInstance extends IsDateTime[Date] {
     */
   override def set[F <: CronField](dateTime: Date,
                                    field: F,
-                                   value: Int): Option[Date] = {
+                                   value: Int): Either[DateTimeError, Date] = {
     def setter(f: Date => Unit): Date = {
       val newDateTime = Moment(dateTime)
       f(newDateTime)
       newDateTime
     }
 
-    Some(field match {
+    Right(field match {
       case Second     => setter(_.second(value.toDouble).millisecond(0))
       case Minute     => setter(_.minute(value.toDouble))
       case Hour       => setter(_.hour(value.toDouble))


### PR DESCRIPTION
Adds failure handling when setting values into datetime objects, such that if invalid values to a field are assigned, the stepping process can recover from those by rolling up the next field in the chain.

Fixes #73 and #80