### PR TITLE
Parse comparison between stdlib and atto

### DIFF
--- a/bench/src/main/scala/cron4s/bench/ParserBenchmark.scala
+++ b/bench/src/main/scala/cron4s/bench/ParserBenchmark.scala
@@ -1,0 +1,26 @@
+package cron4s.bench
+
+import cron4s._
+
+import org.openjdk.jmh.annotations._
+
+@State(Scope.Thread)
+class ParserBenchmark {
+
+  @Param(
+    Array(
+      "10-35 2,4,6 * ? * *",
+      "* 5,10,15,20,25,30,35,40,45,50,55/2 * ? * mon-fri",
+      "10-65 * * * * *",
+      "* */10 5-10 ? * mon-fri"
+    )
+  )
+  var cronString: String = _
+
+  @Benchmark
+  def parserCombinators() = parsing.parse(cronString)
+
+  @Benchmark
+  def attoParser() = atto.parse(cronString)
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -327,6 +327,7 @@ lazy val bench = (project in file("bench"))
   .settings(commonSettings)
   .settings(noPublishSettings)
   .settings(commonJvmSettings)
+  .settings(Dependencies.bench)
   .enablePlugins(JmhPlugin)
   .dependsOn(coreJVM)
 

--- a/modules/core/shared/src/main/scala/cron4s/Cron.scala
+++ b/modules/core/shared/src/main/scala/cron4s/Cron.scala
@@ -51,7 +51,7 @@ object Cron {
     */
   @inline
   def parse(e: String): Either[Error, CronExpr] =
-    parse0(e).right.flatMap(validation.validateCron)
+    parsing.parse(e).right.flatMap(validation.validateCron)
 
   /**
     * Parses the given cron expression into a cron AST using Try as return type
@@ -60,7 +60,7 @@ object Cron {
     * @return a Try representing the failure or the actual parsed cron AST
     * @example val cron = Cron.tryParse("10-35 2,4,6 * ? * *")
     */
-  def tryParse(e: String): Try[CronExpr] = parse(e) match {
+  def tryParse(e: String): Try[CronExpr] = parsing.parse(e) match {
     case Left(err)   => Failure(err)
     case Right(expr) => Success(expr)
   }
@@ -80,9 +80,4 @@ object Cron {
     case Right(expr) => expr
   }
 
-  private[this] def parse0(e: String): Either[Error, CronExpr] =
-    for {
-      tokens <- CronLexer.tokenize(e)
-      expr   <- CronParser.read(tokens)
-    } yield expr
 }

--- a/modules/core/shared/src/main/scala/cron4s/Cron.scala
+++ b/modules/core/shared/src/main/scala/cron4s/Cron.scala
@@ -16,10 +16,6 @@
 
 package cron4s
 
-import cats.syntax.either._
-
-import cron4s.parsing._
-
 import scala.scalajs.js.annotation.JSExportTopLevel
 import scala.util.{Failure, Success, Try}
 
@@ -60,7 +56,7 @@ object Cron {
     * @return a Try representing the failure or the actual parsed cron AST
     * @example val cron = Cron.tryParse("10-35 2,4,6 * ? * *")
     */
-  def tryParse(e: String): Try[CronExpr] = parsing.parse(e) match {
+  def tryParse(e: String): Try[CronExpr] = parse(e) match {
     case Left(err)   => Failure(err)
     case Right(expr) => Success(expr)
   }

--- a/modules/core/shared/src/main/scala/cron4s/atto/package.scala
+++ b/modules/core/shared/src/main/scala/cron4s/atto/package.scala
@@ -1,0 +1,150 @@
+package cron4s
+
+import _root_.atto._
+import Atto._
+import cats.implicits._
+
+import cron4s.expr._
+
+package object atto {
+  import CronField._
+  import CronUnit._
+
+  private val sexagesimal: Parser[Int] = int.filter(x => x >= 0 && x < 60)
+  private val decimal: Parser[Int]     = int.filter(x => x >= 0)
+  private val literal: Parser[String]  = takeWhile1(_ >= ' ')
+
+  private val hyphen: Parser[Char]       = elem(_ == '-', "hyphen")
+  private val comma: Parser[Char]        = elem(_ == ',', "comma")
+  private val slash: Parser[Char]        = elem(_ == '/', "slash")
+  private val asterisk: Parser[Char]     = elem(_ == '*', "asterisk")
+  private val questionMark: Parser[Char] = elem(_ == '?', "question-mark")
+  private val blank: Parser[Char]        = elem(_ == ' ', "blank")
+
+  //----------------------------------------
+  // Individual Expression Atoms
+  //----------------------------------------
+
+  // Seconds
+
+  val seconds: Parser[ConstNode[Second]] =
+    sexagesimal.map(ConstNode[Second](_))
+
+  // Minutes
+
+  val minutes: Parser[ConstNode[Minute]] =
+    sexagesimal.map(ConstNode[Minute](_))
+
+  // Hours
+
+  val hours: Parser[ConstNode[Hour]] =
+    decimal.filter(x => (x >= 0) && (x < 24)).map(ConstNode[Hour](_))
+
+  // Days Of Month
+
+  val daysOfMonth: Parser[ConstNode[DayOfMonth]] =
+    decimal.filter(x => (x >= 1) && (x <= 31)).map(ConstNode[DayOfMonth](_))
+
+  // Months
+
+  private[this] val numericMonths =
+    decimal.filter(_ <= 12).map(ConstNode[Month](_))
+
+  private[this] val textualMonths =
+    literal.filter(Months.textValues.contains).map { value =>
+      val index = Months.textValues.indexOf(value)
+      ConstNode[Month](index + 1, Some(value))
+    }
+
+  val months: Parser[ConstNode[Month]] =
+    textualMonths | numericMonths
+
+  // Days Of Week
+
+  private[this] val numericDaysOfWeek =
+    decimal.filter(_ < 7).map(ConstNode[DayOfWeek](_))
+
+  private[this] val textualDaysOfWeek =
+    literal.filter(DaysOfWeek.textValues.contains).map { value =>
+      val index = DaysOfWeek.textValues.indexOf(value)
+      ConstNode[DayOfWeek](index, Some(value))
+    }
+
+  val daysOfWeek: Parser[ConstNode[DayOfWeek]] =
+    textualDaysOfWeek | numericDaysOfWeek
+
+  //----------------------------------------
+  // Field-Based Expression Atoms
+  //----------------------------------------
+
+  def each[F <: CronField](implicit unit: CronUnit[F]): Parser[EachNode[F]] =
+    asterisk.as(EachNode[F])
+
+  def any[F <: CronField](implicit unit: CronUnit[F]): Parser[AnyNode[F]] =
+    questionMark.as(AnyNode[F])
+
+  def between[F <: CronField](base: => Parser[ConstNode[F]])(
+      implicit unit: CronUnit[F]
+  ): Parser[BetweenNode[F]] =
+    for {
+      min <- delay(base) <~ hyphen
+      max <- delay(base)
+    } yield BetweenNode[F](min, max)
+
+  def several[F <: CronField](base: => Parser[ConstNode[F]])(
+      implicit unit: CronUnit[F]
+  ): Parser[SeveralNode[F]] = {
+    def compose(b: => Parser[EnumerableNode[F]]) =
+      sepBy1(delay(b), comma).map(values => SeveralNode.fromSeq[F](values.toList).get)
+
+    compose(between(base).map(between2Enumerable) | base.map(const2Enumerable))
+  }
+
+  def every[F <: CronField](base: => Parser[ConstNode[F]])(
+      implicit unit: CronUnit[F]
+  ): Parser[EveryNode[F]] = {
+    def compose(b: => Parser[DivisibleNode[F]]) =
+      ((delay(b) <~ slash) ~ decimal.filter(_ > 0)).map {
+        case (exp, freq) => EveryNode[F](exp, freq)
+      }
+
+    compose(
+      several(base).map(several2Divisible) |
+        between(base).map(between2Divisible) |
+        each[F].map(each2Divisible)
+    )
+  }
+
+  //----------------------------------------
+  // AST Parsing & Building
+  //----------------------------------------
+
+  def field[F <: CronField](base: Parser[ConstNode[F]])(
+      implicit unit: CronUnit[F]
+  ): Parser[FieldNode[F]] =
+    every(base).map(every2Field) |
+      several(base).map(several2Field) |
+      between(base).map(between2Field) |
+      base.map(const2Field) |
+      each[F].map(each2Field)
+
+  def fieldWithAny[F <: CronField](base: Parser[ConstNode[F]])(
+      implicit unit: CronUnit[F]
+  ): Parser[FieldNodeWithAny[F]] =
+    every(base).map(every2FieldWithAny) |
+      several(base).map(several2FieldWithAny) |
+      between(base).map(between2FieldWithAny) |
+      base.map(const2FieldWithAny) |
+      each[F].map(each2FieldWithAny) |
+      any[F].map(any2FieldWithAny)
+
+  val cron: Parser[CronExpr] = for {
+    sec     <- field(seconds) <~ blank
+    min     <- field(minutes) <~ blank
+    hour    <- field(hours) <~ blank
+    day     <- fieldWithAny(daysOfMonth) <~ blank
+    month   <- field(months) <~ blank
+    weekDay <- fieldWithAny(daysOfWeek)
+  } yield CronExpr(sec, min, hour, day, month, weekDay)
+
+}

--- a/modules/core/shared/src/main/scala/cron4s/parsing/package.scala
+++ b/modules/core/shared/src/main/scala/cron4s/parsing/package.scala
@@ -1,0 +1,11 @@
+package cron4s
+
+package object parsing {
+
+  private[cron4s] def parse(e: String): Either[Error, CronExpr] =
+    for {
+      tokens <- CronLexer.tokenize(e)
+      expr   <- CronParser.read(tokens)
+    } yield expr
+
+}

--- a/modules/core/shared/src/main/scala/cron4s/parsing/package.scala
+++ b/modules/core/shared/src/main/scala/cron4s/parsing/package.scala
@@ -1,5 +1,7 @@
 package cron4s
 
+import cats.syntax.either._
+
 package object parsing {
 
   private[cron4s] def parse(e: String): Either[Error, CronExpr] =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,8 +41,7 @@ object Dependencies {
     libraryDependencies ++= compilerPlugins ++ Seq(
       "com.chuusai"            %%% "shapeless"                % version.shapeless,
       "org.typelevel"          %%% "cats-core"                % version.cats,
-      "com.propensive"         %%% "contextual"               % version.contextual,
-      "org.tpolecat"           %%% "atto-core"                % version.atto,
+      "com.propensive"         %%% "contextual"               % version.contextual,      
       "org.scala-lang.modules" %%% "scala-parser-combinators" % version.parser,
     )
   }
@@ -80,6 +79,12 @@ object Dependencies {
     libraryDependencies ++= Seq(
       "joda-time" % "joda-time"    % version.jodaTime,
       "org.joda"  % "joda-convert" % version.jodaConvert
+    )
+  }
+
+  lazy val bench = Def.settings {
+    libraryDependencies ++= Seq(
+      "org.tpolecat" %% "atto-core" % version.atto,
     )
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,6 +9,7 @@ import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport.scalaJSVersion
 object Dependencies {
 
   object version {
+    val atto       = "0.6.5"
     val cats       = "1.6.0"
     val shapeless  = "2.3.3"
     val scalacheck = "1.14.0"
@@ -41,6 +42,7 @@ object Dependencies {
       "com.chuusai"            %%% "shapeless"                % version.shapeless,
       "org.typelevel"          %%% "cats-core"                % version.cats,
       "com.propensive"         %%% "contextual"               % version.contextual,
+      "org.tpolecat"           %%% "atto-core"                % version.atto,
       "org.scala-lang.modules" %%% "scala-parser-combinators" % version.parser,
     )
   }

--- a/runBench.sh
+++ b/runBench.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+sbt "bench/jmh:run -r 2 -i 10 -w 2 -wi 20 -f 1 -t 1 cron4s.bench.*Benchmark"


### PR DESCRIPTION
Re-implements the parsing using tpolecat/atto and adds a benchmark comparing the throughput of it versus the Scala stdlib parser combinators.

The results give the lead to parser combinators, but will leave the atto code in the bench module so this can be re-evaluated later.