### PR TITLE
update: prepare tests for scala 3

### DIFF
--- a/modules/testkit/shared/src/main/scala/cron4s/testkit/CronDateTimeTestKit.scala
+++ b/modules/testkit/shared/src/main/scala/cron4s/testkit/CronDateTimeTestKit.scala
@@ -21,7 +21,7 @@ import cats.implicits._
 
 import cron4s.Cron
 import cron4s.datetime.IsDateTime
-
+import cron4s.syntax.all.toDateTimeCronOps
 import org.scalatest.flatspec.AnyFlatSpec
 
 /**

--- a/modules/testkit/shared/src/main/scala/cron4s/testkit/gen/ArbitraryBetweenNode.scala
+++ b/modules/testkit/shared/src/main/scala/cron4s/testkit/gen/ArbitraryBetweenNode.scala
@@ -15,7 +15,7 @@
  */
 
 package cron4s.testkit.gen
-
+import cron4s.expr.BetweenNode
 import cron4s.CronField._
 
 import org.scalacheck.Arbitrary
@@ -24,10 +24,20 @@ import org.scalacheck.Arbitrary
   * Created by alonsodomin on 28/08/2016.
   */
 trait ArbitraryBetweenNode extends NodeGenerators {
-  implicit lazy val arbitraryBetweenSecond     = Arbitrary(betweenGen[Second])
-  implicit lazy val arbitraryBetweenMinute     = Arbitrary(betweenGen[Minute])
-  implicit lazy val arbitraryBetweenHour       = Arbitrary(betweenGen[Hour])
-  implicit lazy val arbitraryBetweenDayOfMonth = Arbitrary(betweenGen[DayOfMonth])
-  implicit lazy val arbitraryBetweenMonth      = Arbitrary(betweenGen[Month])
-  implicit lazy val arbitraryBetweenDayOfWeek  = Arbitrary(betweenGen[DayOfWeek])
+  implicit lazy val arbitraryBetweenSecond: Arbitrary[BetweenNode[Second]] = Arbitrary(
+    betweenGen[Second]
+  )
+  implicit lazy val arbitraryBetweenMinute: Arbitrary[BetweenNode[Minute]] = Arbitrary(
+    betweenGen[Minute]
+  )
+  implicit lazy val arbitraryBetweenHour: Arbitrary[BetweenNode[Hour]] = Arbitrary(betweenGen[Hour])
+  implicit lazy val arbitraryBetweenDayOfMonth: Arbitrary[BetweenNode[DayOfMonth]] = Arbitrary(
+    betweenGen[DayOfMonth]
+  )
+  implicit lazy val arbitraryBetweenMonth: Arbitrary[BetweenNode[Month]] = Arbitrary(
+    betweenGen[Month]
+  )
+  implicit lazy val arbitraryBetweenDayOfWeek: Arbitrary[BetweenNode[DayOfWeek]] = Arbitrary(
+    betweenGen[DayOfWeek]
+  )
 }

--- a/modules/testkit/shared/src/main/scala/cron4s/testkit/gen/ArbitraryConstNode.scala
+++ b/modules/testkit/shared/src/main/scala/cron4s/testkit/gen/ArbitraryConstNode.scala
@@ -17,6 +17,7 @@
 package cron4s.testkit.gen
 
 import cron4s.CronField._
+import cron4s.expr.ConstNode
 
 import org.scalacheck.Arbitrary
 
@@ -24,10 +25,14 @@ import org.scalacheck.Arbitrary
   * Created by alonsodomin on 28/08/2016.
   */
 trait ArbitraryConstNode extends NodeGenerators {
-  implicit lazy val arbitraryConstSecond     = Arbitrary(constGen[Second])
-  implicit lazy val arbitraryConstMinute     = Arbitrary(constGen[Minute])
-  implicit lazy val arbitraryConstHour       = Arbitrary(constGen[Hour])
-  implicit lazy val arbitraryConstDayOfMonth = Arbitrary(constGen[DayOfMonth])
-  implicit lazy val arbitraryConstMonth      = Arbitrary(constGen[Month])
-  implicit lazy val arbitraryConstDayOfWeek  = Arbitrary(constGen[DayOfWeek])
+  implicit lazy val arbitraryConstSecond: Arbitrary[ConstNode[Second]] = Arbitrary(constGen[Second])
+  implicit lazy val arbitraryConstMinute: Arbitrary[ConstNode[Minute]] = Arbitrary(constGen[Minute])
+  implicit lazy val arbitraryConstHour: Arbitrary[ConstNode[Hour]]     = Arbitrary(constGen[Hour])
+  implicit lazy val arbitraryConstDayOfMonth: Arbitrary[ConstNode[DayOfMonth]] = Arbitrary(
+    constGen[DayOfMonth]
+  )
+  implicit lazy val arbitraryConstMonth: Arbitrary[ConstNode[Month]] = Arbitrary(constGen[Month])
+  implicit lazy val arbitraryConstDayOfWeek: Arbitrary[ConstNode[DayOfWeek]] = Arbitrary(
+    constGen[DayOfWeek]
+  )
 }

--- a/modules/testkit/shared/src/main/scala/cron4s/testkit/gen/ArbitraryCronUnits.scala
+++ b/modules/testkit/shared/src/main/scala/cron4s/testkit/gen/ArbitraryCronUnits.scala
@@ -25,10 +25,22 @@ import org.scalacheck._
   * Created by alonsodomin on 28/08/2016.
   */
 trait ArbitraryCronUnits {
-  implicit lazy val arbitrarySecondsUnit     = Arbitrary(Gen.const(CronUnit[Second]))
-  implicit lazy val arbitraryMinutesUnit     = Arbitrary(Gen.const(CronUnit[Minute]))
-  implicit lazy val arbitraryHoursUnit       = Arbitrary(Gen.const(CronUnit[Hour]))
-  implicit lazy val arbitraryDaysOfMonthUnit = Arbitrary(Gen.const(CronUnit[DayOfMonth]))
-  implicit lazy val arbitraryMonthsUnit      = Arbitrary(Gen.const(CronUnit[Month]))
-  implicit lazy val arbitraryDaysOfWeekUnit  = Arbitrary(Gen.const(CronUnit[DayOfWeek]))
+  implicit lazy val arbitrarySecondsUnit: Arbitrary[CronUnit[Second]] = Arbitrary(
+    Gen.const(CronUnit[Second])
+  )
+  implicit lazy val arbitraryMinutesUnit: Arbitrary[CronUnit[Minute]] = Arbitrary(
+    Gen.const(CronUnit[Minute])
+  )
+  implicit lazy val arbitraryHoursUnit: Arbitrary[CronUnit[Hour]] = Arbitrary(
+    Gen.const(CronUnit[Hour])
+  )
+  implicit lazy val arbitraryDaysOfMonthUnit: Arbitrary[CronUnit[DayOfMonth]] = Arbitrary(
+    Gen.const(CronUnit[DayOfMonth])
+  )
+  implicit lazy val arbitraryMonthsUnit: Arbitrary[CronUnit[Month]] = Arbitrary(
+    Gen.const(CronUnit[Month])
+  )
+  implicit lazy val arbitraryDaysOfWeekUnit: Arbitrary[CronUnit[DayOfWeek]] = Arbitrary(
+    Gen.const(CronUnit[DayOfWeek])
+  )
 }

--- a/modules/testkit/shared/src/main/scala/cron4s/testkit/gen/ArbitraryEachNode.scala
+++ b/modules/testkit/shared/src/main/scala/cron4s/testkit/gen/ArbitraryEachNode.scala
@@ -17,6 +17,7 @@
 package cron4s.testkit.gen
 
 import cron4s.CronField._
+import cron4s.expr.EachNode
 
 import org.scalacheck.Arbitrary
 
@@ -24,10 +25,14 @@ import org.scalacheck.Arbitrary
   * Created by alonsodomin on 28/08/2016.
   */
 trait ArbitraryEachNode extends NodeGenerators {
-  implicit lazy val arbitraryEachSecond     = Arbitrary(eachGen[Second])
-  implicit lazy val arbitraryEachMinute     = Arbitrary(eachGen[Minute])
-  implicit lazy val arbitraryEachHour       = Arbitrary(eachGen[Hour])
-  implicit lazy val arbitraryEachDayOfMonth = Arbitrary(eachGen[DayOfMonth])
-  implicit lazy val arbitraryEachMonth      = Arbitrary(eachGen[Month])
-  implicit lazy val arbitraryEachDayOfWeek  = Arbitrary(eachGen[DayOfWeek])
+  implicit lazy val arbitraryEachSecond: Arbitrary[EachNode[Second]] = Arbitrary(eachGen[Second])
+  implicit lazy val arbitraryEachMinute: Arbitrary[EachNode[Minute]] = Arbitrary(eachGen[Minute])
+  implicit lazy val arbitraryEachHour: Arbitrary[EachNode[Hour]]     = Arbitrary(eachGen[Hour])
+  implicit lazy val arbitraryEachDayOfMonth: Arbitrary[EachNode[DayOfMonth]] = Arbitrary(
+    eachGen[DayOfMonth]
+  )
+  implicit lazy val arbitraryEachMonth: Arbitrary[EachNode[Month]] = Arbitrary(eachGen[Month])
+  implicit lazy val arbitraryEachDayOfWeek: Arbitrary[EachNode[DayOfWeek]] = Arbitrary(
+    eachGen[DayOfWeek]
+  )
 }

--- a/modules/testkit/shared/src/main/scala/cron4s/testkit/gen/ArbitraryEveryNode.scala
+++ b/modules/testkit/shared/src/main/scala/cron4s/testkit/gen/ArbitraryEveryNode.scala
@@ -17,17 +17,21 @@
 package cron4s.testkit.gen
 
 import cron4s.CronField._
-
+import cron4s.expr.EveryNode
 import org.scalacheck.Arbitrary
 
 /**
   * Created by alonsodomin on 28/08/2016.
   */
 trait ArbitraryEveryNode extends NodeGenerators {
-  implicit lazy val arbitraryEverySecond     = Arbitrary(everyGen[Second])
-  implicit lazy val arbitraryEveryMinute     = Arbitrary(everyGen[Minute])
-  implicit lazy val arbitraryEveryHour       = Arbitrary(everyGen[Hour])
-  implicit lazy val arbitraryEveryDayOfMonth = Arbitrary(everyGen[DayOfMonth])
-  implicit lazy val arbitraryEveryMonth      = Arbitrary(everyGen[Month])
-  implicit lazy val arbitraryEveryDayOfWeek  = Arbitrary(everyGen[DayOfWeek])
+  implicit lazy val arbitraryEverySecond: Arbitrary[EveryNode[Second]] = Arbitrary(everyGen[Second])
+  implicit lazy val arbitraryEveryMinute: Arbitrary[EveryNode[Minute]] = Arbitrary(everyGen[Minute])
+  implicit lazy val arbitraryEveryHour: Arbitrary[EveryNode[Hour]]     = Arbitrary(everyGen[Hour])
+  implicit lazy val arbitraryEveryDayOfMonth: Arbitrary[EveryNode[DayOfMonth]] = Arbitrary(
+    everyGen[DayOfMonth]
+  )
+  implicit lazy val arbitraryEveryMonth: Arbitrary[EveryNode[Month]] = Arbitrary(everyGen[Month])
+  implicit lazy val arbitraryEveryDayOfWeek: Arbitrary[EveryNode[DayOfWeek]] = Arbitrary(
+    everyGen[DayOfWeek]
+  )
 }

--- a/modules/testkit/shared/src/main/scala/cron4s/testkit/gen/ArbitrarySeveralNode.scala
+++ b/modules/testkit/shared/src/main/scala/cron4s/testkit/gen/ArbitrarySeveralNode.scala
@@ -17,6 +17,7 @@
 package cron4s.testkit.gen
 
 import cron4s.CronField._
+import cron4s.expr.SeveralNode
 
 import org.scalacheck.Arbitrary
 
@@ -24,10 +25,20 @@ import org.scalacheck.Arbitrary
   * Created by alonsodomin on 28/08/2016.
   */
 trait ArbitrarySeveralNode extends NodeGenerators {
-  implicit lazy val arbitrarySeveralSecond     = Arbitrary(severalGen[Second])
-  implicit lazy val arbitrarySeveralMinute     = Arbitrary(severalGen[Minute])
-  implicit lazy val arbitrarySeveralHour       = Arbitrary(severalGen[Hour])
-  implicit lazy val arbitrarySeveralDayOfMonth = Arbitrary(severalGen[DayOfMonth])
-  implicit lazy val arbitrarySeveralMonth      = Arbitrary(severalGen[Month])
-  implicit lazy val arbitrarySeveralDayOfWeek  = Arbitrary(severalGen[DayOfWeek])
+  implicit lazy val arbitrarySeveralSecond: Arbitrary[SeveralNode[Second]] = Arbitrary(
+    severalGen[Second]
+  )
+  implicit lazy val arbitrarySeveralMinute: Arbitrary[SeveralNode[Minute]] = Arbitrary(
+    severalGen[Minute]
+  )
+  implicit lazy val arbitrarySeveralHour: Arbitrary[SeveralNode[Hour]] = Arbitrary(severalGen[Hour])
+  implicit lazy val arbitrarySeveralDayOfMonth: Arbitrary[SeveralNode[DayOfMonth]] = Arbitrary(
+    severalGen[DayOfMonth]
+  )
+  implicit lazy val arbitrarySeveralMonth: Arbitrary[SeveralNode[Month]] = Arbitrary(
+    severalGen[Month]
+  )
+  implicit lazy val arbitrarySeveralDayOfWeek: Arbitrary[SeveralNode[DayOfWeek]] = Arbitrary(
+    severalGen[DayOfWeek]
+  )
 }

--- a/modules/testkit/shared/src/main/scala/cron4s/testkit/gen/ArbitratyAnyNode.scala
+++ b/modules/testkit/shared/src/main/scala/cron4s/testkit/gen/ArbitratyAnyNode.scala
@@ -15,6 +15,7 @@
  */
 
 package cron4s.testkit.gen
+import cron4s.expr.AnyNode
 
 import cron4s.CronField._
 
@@ -24,10 +25,14 @@ import org.scalacheck.Arbitrary
   * Created by alonsodomin on 10/02/2017.
   */
 trait ArbitratyAnyNode extends NodeGenerators {
-  implicit lazy val arbitraryAnySecond     = Arbitrary(anyGen[Second])
-  implicit lazy val arbitraryAnyMinute     = Arbitrary(anyGen[Minute])
-  implicit lazy val arbitraryAnyHour       = Arbitrary(anyGen[Hour])
-  implicit lazy val arbitraryAnyDayOfMonth = Arbitrary(anyGen[DayOfMonth])
-  implicit lazy val arbitraryAnyMonth      = Arbitrary(anyGen[Month])
-  implicit lazy val arbitraryAnyDayOfWeek  = Arbitrary(anyGen[DayOfWeek])
+  implicit lazy val arbitraryAnySecond: Arbitrary[AnyNode[Second]] = Arbitrary(anyGen[Second])
+  implicit lazy val arbitraryAnyMinute: Arbitrary[AnyNode[Minute]] = Arbitrary(anyGen[Minute])
+  implicit lazy val arbitraryAnyHour: Arbitrary[AnyNode[Hour]]     = Arbitrary(anyGen[Hour])
+  implicit lazy val arbitraryAnyDayOfMonth: Arbitrary[AnyNode[DayOfMonth]] = Arbitrary(
+    anyGen[DayOfMonth]
+  )
+  implicit lazy val arbitraryAnyMonth: Arbitrary[AnyNode[Month]] = Arbitrary(anyGen[Month])
+  implicit lazy val arbitraryAnyDayOfWeek: Arbitrary[AnyNode[DayOfWeek]] = Arbitrary(
+    anyGen[DayOfWeek]
+  )
 }

--- a/modules/testkit/shared/src/main/scala/cron4s/testkit/gen/NodeGenerators.scala
+++ b/modules/testkit/shared/src/main/scala/cron4s/testkit/gen/NodeGenerators.scala
@@ -19,8 +19,9 @@ package cron4s.testkit.gen
 import cron4s.{CronField, CronUnit}
 import cron4s.expr._
 import cron4s.base._
-
 import org.scalacheck._
+import cron4s.syntax.all.toExprOps
+import cron4s.syntax.all.toEnumeratedOps
 
 /**
   * Created by alonsodomin on 28/08/2016.

--- a/tests/shared/src/test/scala/cron4s/base/PredicateSpec.scala
+++ b/tests/shared/src/test/scala/cron4s/base/PredicateSpec.scala
@@ -31,11 +31,11 @@ import org.scalacheck._
 class PredicateSpec extends Cron4sLawSuite {
   import Arbitrary._
 
-  implicit lazy val arbitraryPredicate = Arbitrary[Predicate[Int]] {
+  implicit lazy val arbitraryPredicate: Arbitrary[Predicate[Int]] = Arbitrary[Predicate[Int]] {
     for { x <- arbitrary[Int] } yield equalTo(x)
   }
 
-  implicit val predicateEq = Eq.by[Predicate[Int], Boolean](_.apply(0))
+  implicit val predicateEq: Eq[Predicate[Int]] = Eq.by[Predicate[Int], Boolean](_.apply(0))
 
   checkAll("ContravariantPredicate", ContravariantTests[Predicate].contravariant[Int, Int, Int])
   checkAll(


### PR DESCRIPTION
- implicit val/def needs explicit type annotation in scala 3
- implicit conversions must be explicit in scala 3