### PR TITLE
Fix doc generation failure due to @JSExportTopLevel not being on the …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -348,7 +348,9 @@ lazy val testkit =
     .jsSettings(commonJsSettings)
     .jvmSettings(commonJvmSettings)
     .jvmSettings(consoleSettings)
+    .jvmSettings(Dependencies.coreJVM)
     .jvmSettings(mimaSettings("testkit"))
+    .nativeSettings(Dependencies.coreNative)
     .dependsOn(core)
 
 lazy val tests = (crossProject(JSPlatform, JVMPlatform, NativePlatform) in file("tests"))
@@ -427,7 +429,9 @@ lazy val circe =
     .settings(Dependencies.circe)
     .settings(mimaSettings("circe"))
     .jvmSettings(commonJvmSettings)
+    .jvmSettings(Dependencies.coreJVM)
     .jsSettings(commonJsSettings)
+    .nativeSettings(Dependencies.coreNative)
     .dependsOn(core, testkit % Test)
 
 lazy val decline =
@@ -445,7 +449,9 @@ lazy val decline =
     .settings(Dependencies.decline)
     .settings(mimaSettings("decline"))
     .jvmSettings(commonJvmSettings)
+    .jvmSettings(Dependencies.coreJVM)
     .jsSettings(commonJsSettings)
+    .nativeSettings(Dependencies.coreNative)
     .dependsOn(core, testkit % Test)
 
 lazy val doobie = (project in file("modules/doobie"))
@@ -460,6 +466,7 @@ lazy val doobie = (project in file("modules/doobie"))
   .settings(commonJvmSettings)
   .settings(mimaSettings("doobie"))
   .settings(Dependencies.doobie)
+  .settings(Dependencies.coreJVM)
   .dependsOn(core.jvm, testkit.jvm % Test)
 
 // =================================================================================

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.14.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.15.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.16")


### PR DESCRIPTION
…classpath

This problem prevents the scala 3 support from being release https://github.com/alonsodomin/cron4s/issues/468#issuecomment-1872615823