### PR TITLE
fix: the CI fails because of a specific js Date behavior

### DIFF
--- a/modules/testkit/shared/src/main/scala/cron4s/testkit/DateTimeTestKitBase.scala
+++ b/modules/testkit/shared/src/main/scala/cron4s/testkit/DateTimeTestKitBase.scala
@@ -26,14 +26,16 @@ import org.scalacheck.{Arbitrary, Gen}
   * Created by alonsodomin on 29/08/2016.
   */
 trait DateTimeTestKitBase[DateTime] {
-  implicit final lazy val arbitraryDateTime: Arbitrary[DateTime] = Arbitrary(for {
+  protected def genDateTime: Gen[DateTime] = for {
     second     <- Gen.choose(Seconds.min, Seconds.max)
     minute     <- Gen.choose(Minutes.min, Minutes.max)
     hour       <- Gen.choose(Hours.min, Hours.max)
     year       <- Gen.choose(1990, 2020)
     yearMonth  <- Gen.choose(Months.min, Months.max).map(YearMonth.of(year, _))
     dayOfMonth <- Gen.choose(DaysOfMonth.min, yearMonth.lengthOfMonth())
-  } yield createDateTime(second, minute, hour, dayOfMonth, yearMonth.getMonthValue, year))
+  } yield createDateTime(second, minute, hour, dayOfMonth, yearMonth.getMonthValue, year)
+
+  implicit final lazy val arbitraryDateTime: Arbitrary[DateTime] = Arbitrary(genDateTime)
 
   protected def createDateTime(
       seconds: Int,

--- a/tests/js/src/test/scala/cron4s/lib/js/JSDateSpec.scala
+++ b/tests/js/src/test/scala/cron4s/lib/js/JSDateSpec.scala
@@ -17,10 +17,16 @@
 package cron4s.lib.js
 
 import cron4s.testkit.IsDateTimeTestKit
+import org.scalacheck.Gen
 
 import scala.scalajs.js.Date
 
 /**
   * Created by alonsodomin on 02/09/2016.
   */
-class JSDateSpec extends IsDateTimeTestKit[Date]("JSDate") with JSTestBase
+class JSDateSpec extends IsDateTimeTestKit[Date]("JSDate") with JSTestBase {
+  // js date implementation has a very specific behavior when setting month : if the day
+  // doesn't exist in the target month (say the 31) then setting the month to n is actually
+  // setting it to n+1 and it makes property tests to fail
+  override protected def genDateTime: Gen[Date] = super.genDateTime.suchThat(_.getDate() < 29)
+}


### PR DESCRIPTION
Js date implementation has a very specific behavior when setting month : if the day doesn't exist in the target month (say the 31) then setting the month to n is actually setting it to n+1 and it makes property tests to fail