### PR TITLE
Update user guide to clarify cron syntax on index page

### DIFF
--- a/docs/src/main/mdoc/userguide/index.md
+++ b/docs/src/main/mdoc/userguide/index.md
@@ -28,7 +28,7 @@ libraryDependencies += "com.github.alonsodomin.cron4s" %%% "cron4s-core" % "{{si
  * Month (1-12)
  * Day Of Week (0-6, where 0 is Monday)
 
-Textual values are also accepted for Day of Month (`"jan"`, `"feb"`, `"mar"`, `"apr"`, `"may"`, `"jun"`, `"jul"`, 
+Textual values are also accepted for Month (`"jan"`, `"feb"`, `"mar"`, `"apr"`, `"may"`, `"jun"`, `"jul"`, 
 `"ago"`, `"sep"`, `"oct"`, `"nov"`, `"dec"`) and Day of Week (`"mon"`, `"tue"`, `"wed"`, `"thu"`, `"fri"`, `"sat"`, 
 `"sun"`).
 

--- a/docs/src/main/mdoc/userguide/index.md
+++ b/docs/src/main/mdoc/userguide/index.md
@@ -28,6 +28,10 @@ libraryDependencies += "com.github.alonsodomin.cron4s" %%% "cron4s-core" % "{{si
  * Month (1-12)
  * Day Of Week (0-6, where 0 is Monday)
 
+Textual values are also accepted for Day of Month (`"jan"`, `"feb"`, `"mar"`, `"apr"`, `"may"`, `"jun"`, `"jul"`, 
+`"ago"`, `"sep"`, `"oct"`, `"nov"`, `"dec"`) and Day of Week (`"mon"`, `"tue"`, `"wed"`, `"thu"`, `"fri"`, `"sat"`, 
+`"sun"`).
+
 To parse a cron expression into a type that we can work with we will use the `Cron` smart constructor:
 
 ```scala mdoc

--- a/docs/src/main/mdoc/userguide/index.md
+++ b/docs/src/main/mdoc/userguide/index.md
@@ -24,9 +24,9 @@ libraryDependencies += "com.github.alonsodomin.cron4s" %%% "cron4s-core" % "{{si
  * Seconds
  * Minutes
  * Hour Of Day
- * Day Of Month
- * Month
- * Day Of Week
+ * Day Of Month (1-31)
+ * Month (1-12)
+ * Day Of Week (0-6, where 0 is Monday)
 
 To parse a cron expression into a type that we can work with we will use the `Cron` smart constructor:
 


### PR DESCRIPTION
This simple change would have saved me having to look at the source code of cron4s to find out its basic usage